### PR TITLE
React 16 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {Modal, TouchableWithoutFeedback, View} from 'react-native';
 
 const styles = {


### PR DESCRIPTION
React 16 moved PropTypes out of React into its own package