### PR TITLE
Fire onClose when alert is dismissed (iOS)

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ class Overlay extends React.Component {
         transparent
         visible={this.state.visible}
         onRequestClose={this._hideModal}
+        onDismiss={this._hideModal}
         {...extraProps} animationType='none'>
         <TouchableWithoutFeedback onPress={closeOnTouchOutside ? this._hideModal : null}>
           <Animatable.View animation={this.state.overlayAnimationType} duration={animationDuration} easing={easing}


### PR DESCRIPTION
`onClose` doesn't get called in iOS because `_hideModal` isn't getting called from `onDismiss`, which is what is called from iOS when the modal is dismissed:

https://facebook.github.io/react-native/docs/modal.html